### PR TITLE
Order of Operations: Fix Less-than comparisons in operators

### DIFF
--- a/src/token/operator.rs
+++ b/src/token/operator.rs
@@ -69,8 +69,8 @@ impl PartialOrd for Operator {
             if other == value { other_value = *key; }
         };
 
-        if self_value > other_value { return Some(Ordering::Greater); }
         if self_value < other_value { return Some(Ordering::Greater); }
+        if self_value > other_value { return Some(Ordering::Less); }
         None
     }
 }


### PR DESCRIPTION
When comparing two Operators' Order of Operations (OoO) using the less-than operator < we used to incorrectly return `Ordering::Greater` even though we were properly checking if the its order was less than the other operators' order.