### PR TITLE
Fix numeral parsing error in `lexer`

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -35,7 +35,7 @@ pub fn lexer(args: Vec<String>) -> Vec<Token> {
                     curr_op = match &curr_op {
                         Operand::Numeric(val) => {
                             Operand::Numeric(
-                                (val * 10) + (*val as i64 - 48)
+                                (val * 10) + (character as i64 - 48)
                             )
                         },
                         Operand::None => Operand::from(character),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,8 +2,8 @@
 
 // TODO:    Create some random generator for equations and check for:
 //          - Proper evaluation of the final result
-//          - In `to_postfix()`, you can be sure that the order of the operands would be exactly the same
-//          infixed as it is postfixed.
+//          - In `to_postfix()`, you can be sure that the order of the operands would be exactly the same infixed as it is postfixed.
+//          - Create a test that generates large digits and tests its parsing
 //          ...
 
 mod evaluator;

--- a/src/token/operand.rs
+++ b/src/token/operand.rs
@@ -19,7 +19,7 @@ impl From<char> for Operand {
 impl Into<i64> for &Operand {
     fn into(self) -> i64 {
         match self {
-            Operand::Numeric(val) => *val as i64,
+            Operand::Numeric(val) => *val,
             _ => todo!("Conversion into values has not been implemented yet for non-numeral operands."),
         }
     }


### PR DESCRIPTION
This fixes an error where numerals would be lexed incorrectly as the first digit would be incorrectly used instead of the new character. For example:

'12' would be '1', '2' which would be read as:
'1'; would be correctly parsed and added to the operand, then... '2'; it would here read the already converted `1` and then subtract 48 (it assumes that it is converting a char '2' where it actually is incorrectly converting the i64 `1` and then adding it)

You would assume '12' to be read as:
'1'; Operand = 1,
'2'; Operand = 1 + '2' -> (1 * 10) + ('2' as i64 - 48), // You would subtract 48 to convert the ascii code to the actual value

Whereas it is actually read
'1'; Operand = 1,
'2'; Operand = 1 + 1 -> (1 * 10) + (1 as i64 - 48), // In here 1 replaces '2' incorrectly.