### PR TITLE
Evaluator: convert operator-only `Token` type stack into `Operator` type

### DIFF
--- a/src/tests/evaluator.rs
+++ b/src/tests/evaluator.rs
@@ -4,17 +4,17 @@ use crate::token::*;
 
 #[test]
 fn operator_push() {
-    let mut stack: Vec<Token> = Vec::new();
+    let mut stack: Vec<Operator> = Vec::new();
     let mut statement: Vec<Token> = vec!(
         Token::Operand(Operand::Numeric(3)),
     );
-    push_op(Operator::Add, &mut statement, &mut stack);
+    push_op(Operator::Add, &mut stack, &mut statement);
 
     let statement_post = vec!(
         Token::Operand(Operand::Numeric(3)),
     );
     let stack_post = vec!(
-        Token::Operator(Operator::Add),
+        Operator::Add,
     );
     assert_eq!(statement, statement_post);
     assert_eq!(stack, stack_post);


### PR DESCRIPTION
Convert the stack used to store operators in converting the statement into postfix to be an `Operator` type stack previously, it was a `Vec<Token>` but whenever we found an Operand in resolving the stack state, the program panicked; This pull request makes `stack` a `Vec<Operator>` as it should be, which simplifies much of `push_op`.

I have been hestitant to introduce such a change earlier as it does not create any significant change, and the appending of the stack into the statement at the end of the resolution is much simpler when the stack is a `Vec<Token>`

NOTE:

`to_postfix` works by resolving the given operators and leaves some elements in `stack`, when completed, you are supposed to pop each element and append it into the statement. We initially just used

```statement.append(stack)```

Which was incorrect as you should not be simply appending the stack but
removing each element of the _top_ and appending them one by one. By
using `Vec.append()` you are adding the stack bottom to top instead of
top to bottom, to temporarily fix it, I reveresed the satck before
appending it and commented that the operation should be revised,
reversing the stack then appending it is repeated work.

Since the simplicity of maintaining the stack as a `Vec<Token>` was no
longer true, I chose to now change stack to become a `Vec<Operator>`
which greatly simplifies things.